### PR TITLE
Adjust typography on the example page

### DIFF
--- a/examples/src/App.js
+++ b/examples/src/App.js
@@ -66,10 +66,12 @@ function App() {
 
   return (
     <div className={styles.example}>
-      <h3>react-swipeable-list example</h3>
+      <h1>react-swipeable-list example</h1>
       <h5>(try also mobile view in dev tools for touch events)</h5>
       <h3>Simple example (with default 0.5 action trigger threshold)</h3>
-      <span className={styles.actionInfo}>{triggeredSimpleItemAction}</span>
+      <span className={styles.actionInfo}>
+        {triggeredSimpleItemAction || 'No action triggered yet'}
+      </span>
       <div className={styles.listContainer}>
         <SwipeableList>
           <SwipeableListItem
@@ -97,7 +99,9 @@ function App() {
         More complex items and scroll (with 0.25 action trigger threshold)
       </h3>
       <h3>List in smaller container</h3>
-      <span className={styles.actionInfo}>{triggeredComplexItemAction}</span>
+      <span className={styles.actionInfo}>
+        {triggeredComplexItemAction || 'No action triggered yet'}
+      </span>
       <div className={styles.complexListContainer}>
         <SwipeableList threshold={0.25}>
           <SwipeableListItem

--- a/examples/src/app.module.css
+++ b/examples/src/app.module.css
@@ -29,6 +29,7 @@ footer {
   flex-direction: column;
   align-items: center;
   padding: 56px 0;
+  text-align: center;
 }
 
 a {

--- a/examples/src/app.module.css
+++ b/examples/src/app.module.css
@@ -1,7 +1,3 @@
-html {
-  font-family: 'Roboto', sans-serif;
-}
-
 h3 {
   margin-bottom: 0;
   text-align: center;
@@ -13,18 +9,8 @@ h5 {
 }
 
 body {
-  /* stylelint-disable */
-  font-family:
-    system,
-    -apple-system,
-    '.SFNSText-Regular',
-    'San Francisco',
-    'Roboto',
-    'Segoe UI',
-    'Helvetica Neue',
-    'Lucida Grande',
-    sans-serif;
-  /* stylelint-enable */
+  font-family: system, -apple-system, '.SFNSText-Regular', 'San Francisco',
+    'Roboto', 'Segoe UI', 'Helvetica Neue', 'Lucida Grande', sans-serif;
 }
 
 footer {

--- a/examples/src/app.module.css
+++ b/examples/src/app.module.css
@@ -9,18 +9,8 @@ h5 {
 }
 
 body {
-  /* stylelint-disable */
-  font-family:
-    system,
-    -apple-system,
-    '.SFNSText-Regular',
-    'San Francisco',
-    'Roboto',
-    'Segoe UI',
-    'Helvetica Neue',
-    'Lucida Grande',
-    sans-serif;
-  /* stylelint-enable */
+  /* prettier-ignore */
+  font-family: system, -apple-system, '.SFNSText-Regular', 'San Francisco', 'Roboto', 'Segoe UI', 'Helvetica Neue', 'Lucida Grande', sans-serif;
   line-height: 1.7;
 }
 

--- a/examples/src/app.module.css
+++ b/examples/src/app.module.css
@@ -9,6 +9,7 @@ h5 {
 }
 
 body {
+  /* stylelint-disable */
   font-family:
     system,
     -apple-system,
@@ -19,6 +20,7 @@ body {
     'Helvetica Neue',
     'Lucida Grande',
     sans-serif;
+  /* stylelint-enable */
   line-height: 1.7;
 }
 

--- a/examples/src/app.module.css
+++ b/examples/src/app.module.css
@@ -9,8 +9,17 @@ h5 {
 }
 
 body {
-  font-family: system, -apple-system, '.SFNSText-Regular', 'San Francisco',
-    'Roboto', 'Segoe UI', 'Helvetica Neue', 'Lucida Grande', sans-serif;
+  font-family:
+    system,
+    -apple-system,
+    '.SFNSText-Regular',
+    'San Francisco',
+    'Roboto',
+    'Segoe UI',
+    'Helvetica Neue',
+    'Lucida Grande',
+    sans-serif;
+  line-height: 1.7;
 }
 
 footer {

--- a/examples/src/app.module.css
+++ b/examples/src/app.module.css
@@ -14,6 +14,27 @@ body {
   line-height: 1.7;
 }
 
+h1,
+h2,
+h3,
+h4,
+h5 {
+  margin-left: 16px;
+  margin-right: 16px;
+}
+
+h1 {
+  display: block;
+  font-size: 1.17em;
+  margin-block-start: 1em;
+  margin-block-end: 1em;
+  margin-inline-start: 0;
+  margin-inline-end: 0;
+  font-weight: bold;
+  margin-bottom: 0;
+  text-align: center;
+}
+
 footer {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
The following typographic issues were fixed/adjusted:
- The footer text is now always centered
- Line heights were increased to 170% of the font size
- Horizontal margins for text copy was introduced to never make it stick to the phone chrome or screen borders
- Fallback text for action trigger status is now displayed to prevent empty space being shown until the user triggers some action
- A more semantic `h1` tag replaced the `h3` tag of the page title but still uses the same styling.

![chrome_2020-01-23_10-01-29](https://user-images.githubusercontent.com/30114244/72970363-c6b8af80-3dc7-11ea-82f8-310d3deaf3c9.png)