### PR TITLE
fix: adjust children type to be compatible with React 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,12 @@ Type: `boolean` (optional, default: `false`)
 
 If set to `true` all defined swipe actions are blocked.
 
+#### children
+
+Type: `Anything that can be rendered` (required)
+
+Content that is visible by default and swipeable to reveal the left and right views.
+
 ### swipeLeft
 
 Type: `Object` (optional)

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   "browser": "dist/react-swipeable-list.umd.js",
   "peerDependencies": {
     "prop-types": "^15.7.2",
-    "react": "^16.12.0 || ^17",
-    "react-dom": "^16.12.0 || ^17"
+    "react": "^16.12.0 || ^17 || ^18",
+    "react-dom": "^16.12.0 || ^17 || ^18"
   },
   "devDependencies": {
     "@babel/core": "7.13.15",

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -39,6 +39,10 @@ interface ISwipeableListItemProps {
    * If set to `true` all defined swipe actions are blocked.
    */
   blockSwipe?: boolean;
+   /**
+   * Content that is visible by default and swipeable to reveal the left and right views.
+   */
+  children: ReactNode;
   /**
    * Data for defining left swipe action and rendering content after item is swiped.
    */


### PR DESCRIPTION
Based on issue #229, a children property was added to the ISwipeableListItemProps interface.

Fixes #229
Closes #233