### PR TITLE
Fixed types to make the library compatible with React 18

### DIFF
--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -1,4 +1,4 @@
-import { FunctionComponent, PureComponent, ReactNode } from 'react';
+import { FunctionComponent, PropsWithChildren, PureComponent, ReactNode } from 'react';
 
 export enum ActionAnimations {
   /**
@@ -136,7 +136,7 @@ interface ISwipeableListProps extends IBaseSwipeableListProps {
   children?: SwipeableListChildren;
 }
 
-export class SwipeableListItem extends PureComponent<ISwipeableListItemProps> {}
+export class SwipeableListItem extends PureComponent<PropsWithChildren<ISwipeableListItemProps>> {}
 
 /**
  * NOTE: A function child can be used instead of a SwipeableListItem elements.


### PR DESCRIPTION
Since React 18, 'children' isn't an implicit prop any more, one has to set it manually:
https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-typescript-definitions
This hasn't been reflected in the react-swipeable-library's types yet. This is why, I have enhanced SwipeableListItem props with children property.
